### PR TITLE
Make mdn-data a pure build time dependency.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .idea
 node_modules
 .DS_STORE
+.vscode
 
 # ignore generated grammars
 formatted-data

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "scripts": {
     "prepublish": "npm start",
     "test": "./node_modules/.bin/mocha --reporter spec --recursive",
-    "start": "mkdir -p formatted-data src/grammars/generated/json && node ./node_modules/nearley/bin/nearleyc.js ./src/grammars/nearley/formalSyntax.ne > ./src/grammars/js/formalSyntax.js && node ./src/scripts/updateBasicDataUnits.js && node ./src/scripts/formatData.js && node ./src/scripts/formatFormalSyntaxes.js && node ./src/scripts/formatGrammars.js",
+    "start": "./updateCSSData.sh",
     "clean": "rm -rf src/grammars/generated",
     "benchmark": "node test/benchmark.js",
     "doctoc": "node ./node_modules/doctoc/doctoc.js README.md",

--- a/package.json
+++ b/package.json
@@ -42,11 +42,11 @@
     "mocha": "^3.5.0",
     "pre-commit": "^1.2.2",
     "postcss-value-parser": "^3.3.0",
-    "sinon": "^2.4.1"
+    "sinon": "^2.4.1",
+    "mdn-data": "1.0.0"
   },
   "dependencies": {
     "fs-extra": "^3.0.1",
-    "mdn-data": "1.0.0",
     "moo": "^0.4.1",
     "nearley": "^2.11.0"
   }

--- a/src/expandShorthandProperty.js
+++ b/src/expandShorthandProperty.js
@@ -1,5 +1,5 @@
 const nearley = require('nearley');
-const { css: { properties } } = require('mdn-data');
+const properties = require('../formatted-data/properties.json');
 const isShorthandProperty = require('./isShorthandProperty');
 const getShorthandComputedProperties = require('./getShorthandComputedProperties');
 const shorthandProperties = require('../formatted-data/shorthand-properties.json');

--- a/src/getShorthandComputedProperties.js
+++ b/src/getShorthandComputedProperties.js
@@ -1,4 +1,4 @@
-const { css: { properties } } = require('mdn-data');
+const properties = require('../formatted-data/properties.json');
 
 /**
  * Given a shorthand property, returns an array of the computed properties for that shorthand property. If given

--- a/src/getShorthandsForProperty.js
+++ b/src/getShorthandsForProperty.js
@@ -1,5 +1,5 @@
 const shortHandProperties = require('../formatted-data/shorthand-properties.json');
-const { css: { properties } } = require('mdn-data');
+const properties = require('../formatted-data/properties.json');
 
 /**
  * @type {Object}

--- a/src/initialValueMap.js
+++ b/src/initialValueMap.js
@@ -1,4 +1,4 @@
-const { css: { properties } } = require('mdn-data');
+const properties = require('../formatted-data/properties.json');
 const getShorthandComputedProperties = require('./getShorthandComputedProperties');
 const isShorthandProperty = require('./isShorthandProperty');
 

--- a/src/isValidDeclaration.js
+++ b/src/isValidDeclaration.js
@@ -1,5 +1,5 @@
 const nearley = require('nearley');
-const { css: { properties } } = require('mdn-data');
+const properties = require('../formatted-data/properties.json');
 const { CSS } = require('./constants');
 
 /**

--- a/src/scripts/extractProperties.js
+++ b/src/scripts/extractProperties.js
@@ -1,0 +1,14 @@
+/**
+ * Takes raw data from MDN, filters out the shorthand properties, and decorates the data with additional properties.
+ * Writes the formatted data to FORMATTED_DATA_PATH.
+ */
+const fs = require('fs-extra');
+const { css: { properties } } = require('mdn-data');
+const PATHS = require('../constants/paths');
+
+const ALL_PROPERTIES_DATA_FILE_NAME = 'properties.json';
+const OUTPUT_FILE = `${PATHS.FORMATTED_DATA_PATH}${ALL_PROPERTIES_DATA_FILE_NAME}`;
+fs.writeJson(OUTPUT_FILE, properties, { spaces: 2 })
+  .then(() => (
+    console.log(`Successfully extracted properties to ${OUTPUT_FILE}`)
+  ));

--- a/test/InitialValuesTest.js
+++ b/test/InitialValuesTest.js
@@ -1,5 +1,5 @@
 const { assert } = require('chai');
-const { css: { properties: cssProperties } } = require('mdn-data');
+const properties = require('../formatted-data/properties.json');
 const {
    initialValue,
    initialValues,
@@ -31,7 +31,7 @@ describe('Initial values', function () {
       'position',
       'transform-box',
     ]);
-    Object.keys(cssProperties).forEach((prop) => {
+    Object.keys(properties).forEach((prop) => {
       if (prop.startsWith('-') || buggyValues.has(prop)) return; // bug in grammar data
       let initial = initialValue(prop);
       assert(isValidDeclaration(prop, initial), `${prop}: ${initial} is not a legal initial value`);

--- a/updateCSSData.sh
+++ b/updateCSSData.sh
@@ -20,3 +20,4 @@ node ./src/scripts/updateBasicDataUnits.js || exit 1
 node ./src/scripts/formatData.js || exit 1
 node ./src/scripts/formatFormalSyntaxes.js || exit 1
 node ./src/scripts/formatGrammars.js || exit 1
+node ./src/scripts/extractProperties.js || exit 1

--- a/updateCSSData.sh
+++ b/updateCSSData.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+function realpath()
+{
+    f=$@
+    if [ -d "$f" ]; then
+        base=""
+        dir="$f"
+    else
+        base="/$(basename "$f")"
+        dir=$(dirname "$f")
+    fi
+    dir=$(cd "$dir" && /bin/pwd)
+    echo "$dir$base"
+}
+cd "$(dirname "$(realpath "$0")")";
+rm -rf formatted-data src/grammars/generated/json
+mkdir -p formatted-data src/grammars/generated/json
+node ./node_modules/nearley/bin/nearleyc.js ./src/grammars/nearley/formalSyntax.ne > ./src/grammars/js/formalSyntax.js || exit 1
+node ./src/scripts/updateBasicDataUnits.js || exit 1
+node ./src/scripts/formatData.js || exit 1
+node ./src/scripts/formatFormalSyntaxes.js || exit 1
+node ./src/scripts/formatGrammars.js || exit 1


### PR DESCRIPTION
The mdn-data package is not being released to npm on any sort of regular
basis. This change is preparing for the ability to update directly from
the github repo using scripts or submodules.

Also, it's best if all the data is in kept in sync because the mdn-data
changes are not following any sort of semver concepts in how they land
schema or data changes.