### PR TITLE
isShorthandProperty lookup perf. improvement

### DIFF
--- a/src/isShorthandProperty.js
+++ b/src/isShorthandProperty.js
@@ -6,5 +6,5 @@ const shortHandProperties = require('./formatted-data/shorthand-properties.json'
  * @returns {boolean} - true if property is a shorthand, false otherwise
  */
 module.exports = function isShorthandProperty(property) {
-  return Object.keys(shortHandProperties).includes(property);
+  return shortHandProperties[property] != undefined;
 };


### PR DESCRIPTION
Isn't key lookup faster than extracting all keys and checking them one by one, at least for a pure json object ?